### PR TITLE
Make latex build the requirements PDF as its own document

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -44,6 +44,7 @@ source_suffix = '.rst'
 
 # The master toctree document.
 master_doc = 'index'
+requirements_doc = 'requirements/index'
 
 # General information about the project.
 project = u'foodtastechess'
@@ -228,8 +229,10 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'foodtastechess.tex', u'foodtastechess Documentation',
-   u'team food taste', 'manual'),
+    (requirements_doc, 'requirements.tex', u'foodtastechess Requirements',
+     u'team food taste', 'manual'),
+#  (master_doc, 'foodtastechess.tex', u'foodtastechess Documentation',
+#   u'team food taste', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of

--- a/conf.py
+++ b/conf.py
@@ -212,6 +212,8 @@ htmlhelp_basename = 'foodtastechessdoc'
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
+    'classoptions': ',oneside',
+    'babel': '\\usepackage[english]{babel}',
 # The paper size ('letterpaper' or 'a4paper').
 #'papersize': 'letterpaper',
 
@@ -244,10 +246,10 @@ latex_documents = [
 #latex_use_parts = False
 
 # If true, show page references after internal links.
-#latex_show_pagerefs = False
+latex_show_pagerefs = True
 
 # If true, show URL addresses after external links.
-#latex_show_urls = False
+latex_show_urls = True
 
 # Documents to append as an appendix to all manuals.
 #latex_appendices = []

--- a/conf.py
+++ b/conf.py
@@ -241,7 +241,7 @@ latex_documents = [
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-latex_use_parts = True
+#latex_use_parts = False
 
 # If true, show page references after internal links.
 #latex_show_pagerefs = False

--- a/conf.py
+++ b/conf.py
@@ -241,7 +241,7 @@ latex_documents = [
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.
-#latex_use_parts = False
+latex_use_parts = True
 
 # If true, show page references after internal links.
 #latex_show_pagerefs = False

--- a/requirements/index.rst
+++ b/requirements/index.rst
@@ -1,8 +1,6 @@
 Requirements
 ============
 
-Contents:
-
 .. toctree::
     :maxdepth: 3
 


### PR DESCRIPTION
The PDF looks like crap when it's got the index pulling in requirements as part of the same document.

Apparently this is configurable, so here's the configuration.