### PR TITLE
PlantUML and container fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ RUN   gem install rack
 RUN   gem install guard
 RUN   gem install guard-rack
 RUN   gem install guard-shell
+RUN   gem install guard-livereload
+RUN   gem install rack-livereload
+
 
 RUN wget http://garr.dl.sourceforge.net/project/plantuml/plantuml.jar -O /opt/plantuml.jar
 ENV PLANTUML_JAR /opt/plantuml.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get install -y python-pip
 RUN apt-get install -y texlive texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
-RUN apt-get install -y git wget make build-essential
+RUN apt-get install -y git wget make build-essential graphviz
 RUN apt-get install -y openjdk-7-jre
 RUN apt-get install -y ruby-dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get install -y python-pip
 RUN apt-get install -y texlive texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
 RUN apt-get install -y git wget make build-essential
 RUN apt-get install -y openjdk-7-jre
+RUN apt-get install -y ruby-dev
 
 RUN   pip install Sphinx==1.3.1
 RUN   pip install sphinx_rtd_theme
@@ -17,6 +18,11 @@ RUN   pip install sphinx-autobuild
 RUN   pip install sphinx-git
 RUN   pip install sphinxcontrib-programoutput
 RUN   pip install sphinxcontrib-plantuml
+
+RUN   gem install rack
+RUN   gem install guard
+RUN   gem install guard-rack
+RUN   gem install guard-shell
 
 RUN wget http://garr.dl.sourceforge.net/project/plantuml/plantuml.jar -O /opt/plantuml.jar
 ENV PLANTUML_JAR /opt/plantuml.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 FROM  debian:latest
 
-RUN   apt-get update
+RUN apt-get update --fix-missing && apt-get upgrade -y
 
-RUN   DEBIAN_FRONTEND=noninteractive apt-get install -y python-pip
-RUN   DEBIAN_FRONTEND=noninteractive apt-get install -y texlive texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
-RUN   DEBIAN_FRONTEND=noninteractive apt-get install -y git
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get install -y python-pip
+RUN apt-get install -y texlive texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
+RUN apt-get install -y git wget make build-essential
+RUN apt-get install -y openjdk-7-jre
 
 RUN   pip install Sphinx==1.3.1
 RUN   pip install sphinx_rtd_theme
@@ -13,5 +16,9 @@ RUN   pip install sphinx_bootstrap_theme
 RUN   pip install sphinx-autobuild
 RUN   pip install sphinx-git
 RUN   pip install sphinxcontrib-programoutput
+RUN   pip install sphinxcontrib-plantuml
 
-CMD ["/bin/bash"]
+RUN wget http://garr.dl.sourceforge.net/project/plantuml/plantuml.jar -O /opt/plantuml.jar
+ENV PLANTUML_JAR /opt/plantuml.jar
+
+CMD bash

--- a/Guardfile
+++ b/Guardfile
@@ -1,9 +1,11 @@
 notification :off
 
 PORT = ENV['PORT'] || 5500
+RELOAD_PORT = ENV['RELOAD_PORT'] || 35729
+
 
 guard 'rack', :port => PORT do
-  watch /_build\/html\/.*/
+  watch 'config.ru'
 end
 
 
@@ -18,3 +20,7 @@ guard :shell do
 end
 
 `make html`
+
+guard 'livereload', :port => RELOAD_PORT do
+  watch /_build\/html\/.+\.(css|js|html)/
+end

--- a/Guardfile
+++ b/Guardfile
@@ -1,4 +1,3 @@
-interactor :coolline
 notification :off
 
 guard 'rack', :port => 5500 do

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,19 @@
+interactor :coolline
+notification :off
+
+guard 'rack', :port => 5500 do
+  watch /_build\/html\/.*/
+end
+
+
+guard :shell do
+  watch /.*\.rst/ do |m|
+    `make html`
+
+    msg = "#{m[0]} changed, rebuilt."
+    n msg, 'Sphinx'
+    "-> #{msg}"
+  end
+end
+
+`make html`

--- a/Guardfile
+++ b/Guardfile
@@ -1,6 +1,8 @@
 notification :off
 
-guard 'rack', :port => 5500 do
+PORT = ENV['PORT'] || 5500
+
+guard 'rack', :port => PORT do
   watch /_build\/html\/.*/
 end
 

--- a/conf.py
+++ b/conf.py
@@ -50,6 +50,7 @@ source_suffix = '.rst'
 # The master toctree document.
 master_doc = 'index'
 requirements_doc = 'requirements/index'
+guide_doc = 'guide/index'
 
 # General information about the project.
 project = u'foodtastechess'
@@ -249,6 +250,8 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (requirements_doc, 'requirements.tex', u'foodtastechess Requirements',
+     author, 'manual'),
+    (guide_doc, 'docs_guide.tex', u'foodtastechess Docs Writing Guide',
      author, 'manual'),
 #  (master_doc, 'foodtastechess.tex', u'foodtastechess Documentation',
 #   u'team food taste', 'manual'),

--- a/conf.py
+++ b/conf.py
@@ -26,10 +26,15 @@ import shlex
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'
 
+plantuml = 'java -jar {}'.format(os.environ['PLANTUML_JAR'])
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx_git', 'sphinxcontrib.programoutput']
+extensions = [
+    'sphinx_git', 'sphinxcontrib.programoutput', 'sphinx.ext.graphviz',
+    'sphinxcontrib.plantuml',
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,1 @@
+run Rack::File.new('_build/html')

--- a/config.ru
+++ b/config.ru
@@ -1,5 +1,13 @@
+require 'rack-livereload'
+
+PORT = ENV['RELOAD_PORT'] || 35729
+
 map '/' do
+    use Rack::LiveReload,
+        :live_reload_port => PORT
+
     use Rack::Static,
         :urls => [""], :root => File.expand_path('_build/html'), :index => 'index.html'
+
     run lambda {|*|}
 end

--- a/config.ru
+++ b/config.ru
@@ -1,1 +1,5 @@
-run Rack::File.new('_build/html')
+map '/' do
+    use Rack::Static,
+        :urls => [""], :root => File.expand_path('_build/html'), :index => 'index.html'
+    run lambda {|*|}
+end

--- a/guide/index.rst
+++ b/guide/index.rst
@@ -1,0 +1,45 @@
+Docs Writing Guide
+==================
+
+Getting Started
+---------------
+
+First we need to build the Docker image. This can be done by running the
+following command:
+
+    ``docker build -t sphinx-doc .``
+
+Some useful commands have been provided:
+
+
+    ``./makepdf``
+        Generates the PDF files
+
+    ``./watch``
+        Starts a web server that watches for changes to the documentation.
+        This uses port ``5500``.
+
+
+Diagrams
+--------
+
+PlantUML is included in the Docker image and should be used to generate
+UML diagrams.
+
+Example Usage
+`````````````
+
+An example UML diagram:
+
+.. uml::
+    Alice -> Bob: "Hi!"
+    Alice <- Bob: "How are you?"
+
+This diagram is generated with the following::
+
+    .. uml::
+        Alice -> Bob: "Hi!"
+        Alice <- Bob: "How are you?"
+
+For more information, please visit the
+`PlantUML homepage <http://plantuml.com>`_.

--- a/index.rst
+++ b/index.rst
@@ -12,6 +12,7 @@ Contents:
    :maxdepth: 2
 
    requirements/index
+   guide/index
 
 
 

--- a/watch
+++ b/watch
@@ -1,12 +1,15 @@
 #!/bin/bash
 
 PORT=5500
+RELOAD_PORT=35729
 CMD="guard -i -p"
 
 docker run -it --rm  \
     --name sphinx-doc-server \
     -e "PORT=${PORT}" \
+    -e "RELOAD_PORT=${RELOAD_PORT}" \
     -p ${PORT}:${PORT} \
+    -p ${RELOAD_PORT}:${RELOAD_PORT} \
     -v ${PWD}:/doc \
     -w /doc \
     sphinx-doc ${CMD}

--- a/watch
+++ b/watch
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-PORT=8181
-CMD="sphinx-autobuild /doc /doc/_build/html -p ${PORT} -H 0.0.0.0"
+PORT=5500
+CMD="guard -i -p"
 
 docker run -it --rm  \
     --name docs \
     -p ${PORT}:${PORT} \
     -v ${PWD}:/doc \
+    -w /doc \
     sphinx-doc ${CMD}

--- a/watch
+++ b/watch
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-PORT=8181
+PORT=5500
 CMD="guard -i -p"
 
 docker run -it --rm  \
-    --name docs \
+    --name sphinx-doc-server \
     -e "PORT=${PORT}" \
     -p ${PORT}:${PORT} \
     -v ${PWD}:/doc \

--- a/watch
+++ b/watch
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-PORT=5500
+PORT=8181
 CMD="guard -i -p"
 
 docker run -it --rm  \
     --name docs \
+    -e "PORT=${PORT}" \
     -p ${PORT}:${PORT} \
     -v ${PWD}:/doc \
     -w /doc \


### PR DESCRIPTION
In order to get PlantUML working, I had to modify the container to have auto-builds and stuff working.

There's an problem where `sphinx-autobuild` sucks and won't serve content through Docker, so I had to switch to using a different tool. In this case, `guard` from Ruby-land. This all works.

Other things:

- I added a **Docs Writing Guide** where can put tips and tricks. Here I just added the various commands and some UML example to show it working.
- The browser should auto-refresh on changes! No hitting refresh yourself!